### PR TITLE
Adds VPN IP partial matching feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ named `$HOME/.routes.json`
 The above example will route all the traffic for the class C block `9.8.7.*` to your VPN
 server whose IP is `1.2.3.4`
 
+### Remote VPN IP partial matching
+
+```json
+{ "remotes": {
+	"1.2.3": [
+		"9.8.7"
+	]
+} }
+```
+
+The above example will route all the traffic for the class C block `9.8.7.*` to your VPN
+server whose IP partially matches `1.2.3`, for example: `1.2.3.4`, `9.1.2.3`
 
 ### Configuring your VPN
 

--- a/ip-up.php
+++ b/ip-up.php
@@ -360,14 +360,13 @@ function main() {
     $remoteIp = $_SERVER['argv'][5];
     $remoteIpConfigs = expectObjectGetArray($routes['remotes'], "Invalid remotes value in routes.json");
 
-    $remoteIpList = array_keys($remoteIpConfigs)
-    $matchedRemoteIpConfig = false
+    $matchedRemoteIpConfig = false;
 
-    // If we have a list of networks to send to this remote IP, set them
-    for ($i = 0; $i < count($remoteIpList); $i++) {
-        $remoteIpItem = $remoteIpList[$i]
-        if (strpos($remoteIp, $remoteIpItem) !== false) {
-            $matchedRemoteIpConfig = $remoteIpConfigs[$remoteIpItem]
+    // If any of the config remote IP partially matches the actual remote IP, use the config.
+    // If multiple matches occur, the final one will be applied
+    foreach ($remoteIpConfigs as $ip => $config) {
+        if (strpos($remoteIp, $ip) !== false) {
+            $matchedRemoteIpConfig = $remoteIpConfigs[$ip];
         }
     }
 

--- a/ip-up.php
+++ b/ip-up.php
@@ -360,11 +360,21 @@ function main() {
     $remoteIp = $_SERVER['argv'][5];
     $remoteIpConfigs = expectObjectGetArray($routes['remotes'], "Invalid remotes value in routes.json");
 
+    $remoteIpList = array_keys($remoteIpConfigs)
+    $matchedRemoteIpConfig = false
+
     // If we have a list of networks to send to this remote IP, set them
-    if(isset($remoteIpConfigs[$remoteIp])) {
+    for ($i = 0; $i < count($remoteIpList); $i++) {
+        $remoteIpItem = $remoteIpList[$i]
+        if (strpos($remoteIp, $remoteIpItem) !== false) {
+            $matchedRemoteIpConfig = $remoteIpConfigs[$remoteIpItem]
+        }
+    }
+
+    if($matchedRemoteIpConfig) {
 
         logMessage("Configuring routes for $remoteIp");
-        setRoutes($remoteIpConfigs[$remoteIp]);
+        setRoutes($matchedRemoteIpConfig);
     }
     else { // this remote IP is not known by the config
         


### PR DESCRIPTION
If your VPN IP is `1.2.3.4`, you may configure `routes.json` with any of the following, for example:

```
{
  "remotes": {
    "3.4.5": [
      "1.2.3.4",
      "5.6.7.8"
    ]
  }
}
```

Which matches VPN IPs `2.3.4.5`, `3.4.5.6`, `1.3.4.5`, etc